### PR TITLE
Fix missing seperator in match pattern - mod.rs

### DIFF
--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -631,7 +631,7 @@ impl Value {
         let lhs_ty = function.get_local_ty(lhs);
         assert_eq!(lhs_ty, function.get_local_ty(rhs));
         lhs_ty
-      }
+      },
 
       ValueKind::Shl(lhs, _) | ValueKind::Shr(lhs, _)
       => function.get_local_ty(lhs)


### PR DESCRIPTION
Apparently, there was a missing comma in a match pattern in `mod.rs`.